### PR TITLE
Add Vector.at

### DIFF
--- a/Data/Vector/at.kind2
+++ b/Data/Vector/at.kind2
@@ -8,6 +8,14 @@ Data.Vector.at t n (Data.Fin.zero m) Data.Vector.nil =
   let empty = Data.Bool.true_not_false p
   Data.Empty.absurd empty
 Data.Vector.at t n Data.Fin.zero (Data.Vector.cons len head tail) = head
+// proving that this case is impossible
+Data.Vector.at t n (Data.Fin.succ m pred) Data.Vector.nil =
+  let n_eq_0 = Prop.Equal.refl :: Prop.Equal 0n n
+  let n_eq_succ = Prop.Equal.refl :: Prop.Equal n (Data.Nat.succ m)
+  let succ_eq_0 = Prop.Equal.chain n_eq_0 n_eq_succ
+  let p = Prop.Equal.apply (x => Data.Nat.is_zero x) succ_eq_0
+  let empty = Data.Bool.true_not_false p
+  Data.Empty.absurd empty
 Data.Vector.at t n (Data.Fin.succ m idx) (Data.Vector.cons len head tail) =
   // rewriting the tail's type to be Vec t m, instead of Vec t len
   let n_len = Prop.Equal.refl :: Prop.Equal (Data.Nat.succ len) n

--- a/Data/Vector/at.kind2
+++ b/Data/Vector/at.kind2
@@ -1,0 +1,17 @@
+Data.Vector.at <t> <n: Data.Nat> (idx: Data.Fin n) (v: Data.Vector t n) : t
+// proving that this case is impossible
+Data.Vector.at t n (Data.Fin.zero m) Data.Vector.nil =
+  let n_eq_0 = Prop.Equal.refl :: Prop.Equal 0n n
+  let n_eq_succ = Prop.Equal.refl :: Prop.Equal n (Data.Nat.succ m)
+  let succ_eq_0 = Prop.Equal.chain n_eq_0 n_eq_succ
+  let p = Prop.Equal.apply (x => Data.Nat.is_zero x) succ_eq_0
+  let empty = Data.Bool.true_not_false p
+  Data.Empty.absurd empty
+Data.Vector.at t n Data.Fin.zero (Data.Vector.cons len head tail) = head
+Data.Vector.at t n (Data.Fin.succ m idx) (Data.Vector.cons len head tail) =
+  // rewriting the tail's type to be Vec t m, instead of Vec t len
+  let n_len = Prop.Equal.refl :: Prop.Equal (Data.Nat.succ len) n
+  let n_m   = Prop.Equal.refl :: Prop.Equal n (Data.Nat.succ m)
+  let len_eq_m = Prop.Equal.apply (x => Data.Nat.pred x) (Prop.Equal.chain n_len n_m)
+  let tail_ = Prop.Equal.rewrite len_eq_m (x => Data.Vector t x) tail
+  Data.Vector.at idx tail_


### PR DESCRIPTION
Adds Vector.at to index an element from a vector using Fin to provide a safer alternative to List's indexing(that uses Maybe)